### PR TITLE
Fixed issue with use_save_dialog attribute

### DIFF
--- a/pyforms_gui/controls/control_file.py
+++ b/pyforms_gui/controls/control_file.py
@@ -34,13 +34,13 @@ class ControlFile(ControlBase):
     def click(self):
 
         if self.use_save_dialog:
-            value, _ = QFileDialog.getSaveFileName(self.parent, self._label, self.value)
+            value = QFileDialog.getSaveFileName(self.parent, self._label, self.value)
         else:
             value = QFileDialog.getOpenFileName(self.parent, self._label, self.value)
 
         
         if _api.USED_API == _api.QT_API_PYQT5:
-            value = value[0]
+            value = str(value[0])
         elif _api.USED_API == _api.QT_API_PYQT4:
             value = str(value)
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,10 @@ setup(
         'opencv-python',
         'confapp'
     ],
+    dependency_links=[
+        'https://github.com/Vykstorm/confapp/tarball/master#egg=confapp'
+    ],
+
     packages=find_packages(),
     package_data={'pyforms_gui': [
         'controls/uipics/*.png',


### PR DESCRIPTION
Using QT5 API and use_save_dialog set to True on ControlFile, click() method doesn't return the selected path by the user properly.
This is described in the issue: https://github.com/UmSenhorQualquer/pyforms/issues/75
This issue happens because the returned values of the method QFileDialog.getSaveFileName() are unpacked two times.
