### PR TITLE
Fix isuue with ControlImage.py

### DIFF
--- a/tutorials/Controls4Docs/ControlImage.py
+++ b/tutorials/Controls4Docs/ControlImage.py
@@ -28,7 +28,7 @@ class SimpleExample(BaseWidget):
 		self._open.value = self.__open
 		
 	def __open(self):
-		self._control.value = '/home/ricardo/Desktop/lena_color.png'
+		self._control.value = cv2.imread('../2.ControlsExamples/lena.png')
 
 
 


### PR DESCRIPTION
Fix isuue with tutorials\Controls4Docs\ControlImage.py for mixing the variable types.
This issue is caused by the function paint need an array value rather than str. This array value represents the pictures and can be produced by cv2.imread. Also there is a change in the pic path.
`self._control.value = '/home/ricardo/Desktop/lena_color.png`    ->
`self._control.value = cv2.imread('../2.ControlsExamples/lena.png')`