### PR TITLE
Making BaseWidget.save_window() to write a human-readable json file

### DIFF
--- a/pyforms_gui/basewidget.py
+++ b/pyforms_gui/basewidget.py
@@ -284,7 +284,7 @@ class BaseWidget(QFrame):
         filename, _ = QFileDialog.getSaveFileName(self, 'Select file')
         if filename:
             with open(filename, 'w') as output_file:
-                json.dump(data, output_file)
+                json.dump(data, output_file, indent = 4)
 
     def load_form_filename(self, filename):
         with open(filename, 'r') as pkl_file:


### PR DESCRIPTION
Working with big single-line json files is exhausting. I think it's better to have beautiful indented json files so that one can read/edit them (especially on vi/vim).

The json function .dumps() admits the "indent" argument to achieve that. So, It would be nice :)